### PR TITLE
Make calculator more robust and apply cosmetic changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,20 +19,35 @@ dynamics.
 Installation
 ============
 
-|build status|
+Please note, that this package has been tested for Python 3.X support. Its usage
+additionally requires
 
-The package can be installed via conda-forge (available with first release)::
+  - `Atomic Simulation Environment
+    <https://wiki.fysik.dtu.dk/ase/install.html>`_ (`ase`)
+  - `Fortnet Python tools <https://github.com/vanderhe/fortnet-python>`_
+    (`fortnet-python`)
 
-  conda install fortnet-ase
+as well as the `pytest` framework in order to run the regression tests.
 
-Alternatively, the package can be downloaded and installed via pip into the
-active Python interpreter (preferably using a virtual python environment) by ::
+Via the Python Package Index
+----------------------------
+
+The package can be downloaded and installed via pip into the active Python
+interpreter (preferably using a virtual python environment) by ::
 
   pip install fortnet-ase
 
-or into the user space issueing ::
+or into the user space issueing::
 
   pip install --user fortnet-ase
+
+Locally from Source
+-------------------
+
+Alternatively, you can install it locally from source, i.e. from the root folder
+of the project::
+
+  python -m pip install .
 
 Documentation
 =============
@@ -41,8 +56,8 @@ Documentation
 
 Consult following resources for documentation:
 
-* `Step-by-step instructions with selected examples (Fortnet-Ase Recipes)
-  <https://fortnet-ase.readthedocs.io/>`_
+* `Step-by-step instructions with selected examples (Fortnet Recipes)
+  <https://fortnet.readthedocs.io/en/latest/interfaces/index.html>`_
 
 Contributing
 ============
@@ -77,10 +92,10 @@ fortnet-ase is released under the BSD 2-clause license. See the included
 .. |doi| image:: https://zenodo.org/badge/356394988.svg
    :target: https://zenodo.org/badge/latestdoi/356394988
 
-.. |docs status| image:: https://readthedocs.org/projects/fortnet-ase/badge/?version=latest
+.. |docs status| image:: https://readthedocs.org/projects/fortnet/badge/?version=latest
     :alt: Documentation Status
     :scale: 100%
-    :target: https://fortnet-ase.readthedocs.io/en/latest/
+    :target: https://fortnet-python.readthedocs.io/en/latest/
 
 .. |issues| image:: https://img.shields.io/github/issues/vanderhe/fortnet-ase.svg
     :target: https://github.com/vanderhe/fortnet-ase/issues/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pytest
+numpy
+h5py
+ase
+fortnet-python

--- a/src/fnetase/__init__.py
+++ b/src/fnetase/__init__.py
@@ -7,4 +7,5 @@
 
 
 # Pull main classes up to the fnetase top level domain namespace
-from fnetase.calculator import Fortnet
+from .calculator import Fortnet
+from .common import FortnetAseError


### PR DESCRIPTION
Added a check for the BPNN configuration of the netstat file to be read. In particular, the composition of input features in combination with force calculations has been added (currently, the calculation of atomic forces is only supported for purely ACSF based inputs).