### PR TITLE
Use stripped subnetwork element string instead of padded one

### DIFF
--- a/src/fnetase/calculator.py
+++ b/src/fnetase/calculator.py
@@ -170,7 +170,7 @@ def _check_bpnn_configuration(fname, tforces):
 
         for atnum in atomicnumbers:
             element = ELEMENTSYMBOL[atnum - 1]
-            subnet = bpnn[element + '-subnetwork']
+            subnet = bpnn[element.strip() + '-subnetwork']
             topology = np.array(subnet['topology'], dtype=int)
 
             if topology[-1] != 1:


### PR DESCRIPTION
Fixes a bug, where the calculator fails to read an element subnetwork configuration from the fortnet.hdf5 netstat file, because of whitespace padding of strings.